### PR TITLE
Github actions: conf. trigger per pull request.

### DIFF
--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -1,6 +1,9 @@
 name: Commit stage
 
-on: [ push ]
+on:
+  push:
+  pull_request:
+    branches: [ master ]
 
 env:
   PHP_EXTENSIONS: curl, opcache, mbstring, mysql


### PR DESCRIPTION
Miglioramento nella pipeline di GHA,
la precedente conf. si attivava sull' evento push ma non per le pull request.

Ora i vari job (per ora solo lint composer e 1 test) vengono attivati anche sulle richeste di PR facilitando il processo di review (ovviamente nell'ottica di aggiungere + test).
