### PR TITLE
Sistemata schermata autorizzazione uscita per alunni assenti.

### DIFF
--- a/assenze/selealunniautuscita.php
+++ b/assenze/selealunniautuscita.php
@@ -203,8 +203,19 @@ if ($idclasse != "")
             order by cognome, nome, datanascita";
 
     $ris = eseguiQuery($con, $query);
+
+
     while ($rec = mysqli_fetch_array($ris))
     {
+        $alunnoassente = false;
+        $idalu = $rec['idalunno'];
+        $query_ca = "SELECT COUNT(*) FROM `tbl_assenze` WHERE `idalunno` = $idalu AND `data` = CURDATE();";
+        $ris_ca = eseguiQuery($con, $query_ca);
+        $conteggioassenze = mysqli_fetch_array($ris_ca, MYSQLI_NUM);
+        if($conteggioassenze[0] > 0){
+            $alunnoassente = true;
+        }
+
         print "<tr>";
         print "     <td>" . $rec['cognome'] . " " . $rec['nome'] . " " . data_italiana($rec['datanascita']);
         if ($rec['firmapropria'])
@@ -218,9 +229,12 @@ if ($idclasse != "")
         }
         print "</td>";
 
-
-        print "<td align='center'><input type='checkbox' name='pres" . $rec['idalunno'] . "'></td>";
-
+        if($alunnoassente){
+            print "<td align='center'><b>Alunno Assente</b></td>";
+        }else{
+            print "<td align='center'><input type='checkbox' name='pres" . $rec['idalunno'] . "'></td>";
+        }
+        
         print "<td align='center'>";
 
         $seledata = " data <= '" . $_SESSION['fineprimo'] . "' ";

--- a/lezioni/sitleztota.php
+++ b/lezioni/sitleztota.php
@@ -558,19 +558,19 @@ if ($per != "" & $catt != "")
             $visvoto = "";
             $stilerosso = 'style="background-color: #eb4034; border: 1px solid #000000;"';
             $stileverde = 'style="background-color: #05ac50; border: 1px solid #000000;"';
-            //print "tttt $iddocente ttt".$recvot['iddocente'];
-            if ($recvot['iddocente'] != $iddocente)
-                //$visvoto .= "&nbsp;<u>";
+            if ($recvot['iddocente'] != $iddocente) {
                 $visvoto .= "<u>";
-            else
-                //$visvoto .= "&nbsp;";
-            if ($recvot['voto'] >= 6)
+            }
+            if ($recvot['voto'] >= 6){
                 $visvoto .= "<div $stileverde>" . dec_to_mod($recvot['voto']) . "<sub>" . $recvot['tipo'] . "</sub></div>";
+            }
             else
+            {
                 $visvoto .= "<div $stilerosso>" . dec_to_mod($recvot['voto']) . "<sub>" . $recvot['tipo'] . "</sub></div>";
-            if ($recvot['iddocente'] != $iddocente)
+            }
+            if ($recvot['iddocente'] != $iddocente) {
                 $visvoto .= "</u>";
-            
+            }
             $vot[] = $visvoto;
             $lezv[] = $recvot['idlezione'];
         }


### PR DESCRIPTION
**ISSUE:** #67 

**INTERVENTI:**
Nel ciclo che si occupa di stampare la tabella degli alunni, disabilitare gli assenti, per impedire l'inserimento di autorizzazioni su alunni che sono assenti, evitando incongruenze nei dati.

**RISULTATI:**
Da adesso è impossibile inserire autorizzazioni di uscite anticipate su alunni assenti.