### PR TITLE
Controllo cooldown per invio richieste ferie.

### DIFF
--- a/ferie/inviamailrichferie.php
+++ b/ferie/inviamailrichferie.php
@@ -43,6 +43,16 @@ $con = mysqli_connect($db_server, $db_user, $db_password, $db_nome) or die("Erro
 
 $nominativo = estrai_dati_docente($_SESSION['idutente'], $con);
 
+$cooldown_query = "SELECT COUNT(*) FROM `tbl_richiesteferie` WHERE `iddocente` = " . $_SESSION['idutente'] . " AND `oraultmod` > DATE_SUB(NOW(), INTERVAL 5 MINUTE)";
+$cooldown_res = eseguiQuery($con, $cooldown_query);
+$cooldown = mysqli_fetch_array($cooldown_res, MYSQLI_NUM);
+if($cooldown[0] > 0){
+    print "Errore!<br>Puoi inviare solo una richiesta ogni 5 minuti! <br><br>";
+    mysqli_close($con);
+    stampa_piede("");
+    die;
+}
+
 $to = $_SESSION['indirizzomailassenze'];
 
 // NON USATA LA FUNZIONE stringa_html per evitare modifica dei tag html 


### PR DESCRIPTION
Non è più possibile mandare più di una richiesta di ferie da un singolo docente in un corto lasso di tempo (5 minuti).
Questa funzionalità è una richiesta interna scolastica.

Così facendo, chi preme il pulsante di invio numerose volte, non sarà in grado di registrare centinaia di richieste bensì una sola.